### PR TITLE
Update to heapless 0.8.0

### DIFF
--- a/postcard-bindgen-core/Cargo.toml
+++ b/postcard-bindgen-core/Cargo.toml
@@ -27,5 +27,5 @@ version = "0.6.0"
 optional = true
 
 [dependencies.heapless]
-version = "0.7.16"
+version = "0.8.0"
 optional = true

--- a/postcard-bindgen-core/Cargo.toml
+++ b/postcard-bindgen-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postcard-bindgen-core"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["Alexander Hübener <alex.teamplayer@gmail.com>"]
 repository = "https://github.com/teamplayer3/postcard-bindgen.git"

--- a/postcard-bindgen-derive/Cargo.toml
+++ b/postcard-bindgen-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postcard-bindgen-derive"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["Alexander Hübener <alex.teamplayer@gmail.com>"]
 repository = "https://github.com/teamplayer3/postcard-bindgen.git"
@@ -28,6 +28,6 @@ regex = "1.6.0"
 regex-macro = "0.2.0"
 
 [dependencies.postcard-bindgen-core]
-version = "0.3.2"
+version = "0.3.3"
 path = "../postcard-bindgen-core"
 default-features = false

--- a/postcard-bindgen/Cargo.toml
+++ b/postcard-bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postcard-bindgen"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["Alexander Hübener <alex.teamplayer@gmail.com>"]
 repository = "https://github.com/teamplayer3/postcard-bindgen.git"
@@ -23,7 +23,7 @@ alloc = ["postcard-bindgen-core/alloc"]
 heapless = ["postcard-bindgen-core/heapless"]
 
 [dependencies.postcard-bindgen-core]
-version = "0.3.2"
+version = "0.3.3"
 path = "../postcard-bindgen-core"
 
 [dependencies.postcard-bindgen-derive]


### PR DESCRIPTION
It looks like some changes were made to internal namespacing between 0.7.* and 0.8.0 and those changes made bindgen unable to find the traits. This fixes #8 