### PR TITLE
Allow floats to be integers

### DIFF
--- a/postcard-bindgen-core/src/code_gen/generateable/types/number.rs
+++ b/postcard-bindgen-core/src/code_gen/generateable/types/number.rs
@@ -38,7 +38,7 @@ impl JsTypeGenerateable for NumberMeta {
         let byte_amount_str = self.as_byte_js_string();
         match self {
             NumberMeta::FloatingPoint { .. } => {
-                quote!(typeof $(variable_path.to_owned()) === "number" && !Number.isInteger($(variable_path.to_owned())) && Number.isFinite($(variable_path.to_owned())))
+                quote!(typeof $(variable_path.to_owned()) === "number" && Number.isFinite($(variable_path.to_owned())))
             }
             NumberMeta::Integer { signed, .. } => {
                 let signed = bool_to_js_bool(*signed);


### PR DESCRIPTION
Before this change, attempting to encode a floating point number that was exactly an integer, such as 1.0, would fail. This change removes that restriction and only requires the passed number to be finite.

Previously discussed in https://github.com/teamplayer3/postcard-bindgen/issues/24