### PR TITLE
Fix python bindings types cases

### DIFF
--- a/examples/no_std/.gitignore
+++ b/examples/no_std/.gitignore
@@ -1,2 +1,3 @@
 target/
 no_std_bindings/
+no_std_bindings_py/

--- a/examples/no_std/Cargo.lock
+++ b/examples/no_std/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "postcard-bindgen"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "postcard-bindgen-core",
  "postcard-bindgen-derive",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-bindgen-core"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "convert_case",
  "genco",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-bindgen-derive"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "convert_case",
  "genco",

--- a/examples/no_std/gen-bindings.sh
+++ b/examples/no_std/gen-bindings.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-cargo run -p gen-bindings --target $(rustc -vV | sed -n 's|host: ||p')
+
+# nightly is required for Python bindings
+cargo +nightly run -p gen-bindings --target $(rustc -vV | sed -n 's|host: ||p')

--- a/examples/no_std/gen-bindings/src/main.rs
+++ b/examples/no_std/gen-bindings/src/main.rs
@@ -1,17 +1,29 @@
 use postcard_bindgen::{
     generate_bindings,
-    javascript::{build_package, GenerationSettings},
     PackageInfo,
+    javascript,
+    python,
 };
 
 fn main() {
-    build_package(
+    javascript::build_package(
         std::env::current_dir().unwrap().as_path(),
         PackageInfo {
             name: "no_std_bindings".into(),
             version: "0.1.0".try_into().unwrap(),
         },
-        GenerationSettings::enable_all(),
+        javascript::GenerationSettings::enable_all(),
+        generate_bindings!(no_std::Protocol, no_std::Packet, no_std::A1Meta),
+    )
+    .unwrap();
+
+    python::build_package(
+        std::env::current_dir().unwrap().as_path(),
+        PackageInfo {
+            name: "no_std_bindings_py".into(),
+            version: "0.1.0".try_into().unwrap(),
+        },
+        python::GenerationSettings::enable_all(),
         generate_bindings!(no_std::Protocol, no_std::Packet, no_std::A1Meta),
     )
     .unwrap();

--- a/examples/no_std/gen-bindings/src/main.rs
+++ b/examples/no_std/gen-bindings/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
             version: "0.1.0".try_into().unwrap(),
         },
         python::GenerationSettings::enable_all(),
-        generate_bindings!(no_std::Protocol, no_std::Packet, no_std::A1Meta),
+        generate_bindings!(no_std::A1Meta, no_std::Packet, no_std::Protocol),
     )
     .unwrap();
 }

--- a/postcard-bindgen-core/src/code_gen/import_registry.rs
+++ b/postcard-bindgen-core/src/code_gen/import_registry.rs
@@ -36,7 +36,7 @@ impl<L: Lang> ImportRegistry<L> {
                         if !imports.contains(item) {
                             imports.push(item.to_owned());
                         }
-                    },
+                    }
                 },
             })
             .or_insert_with(|| match item {

--- a/postcard-bindgen-core/src/code_gen/import_registry.rs
+++ b/postcard-bindgen-core/src/code_gen/import_registry.rs
@@ -32,7 +32,11 @@ impl<L: Lang> ImportRegistry<L> {
                 ImportItem::All => *e = ImportMode::All,
                 ImportItem::Single(item) => match e {
                     ImportMode::All => (),
-                    ImportMode::Single(imports) => imports.push(item.to_owned()),
+                    ImportMode::Single(imports) => {
+                        if !imports.contains(item) {
+                            imports.push(item.to_owned());
+                        }
+                    },
                 },
             })
             .or_insert_with(|| match item {

--- a/postcard-bindgen-core/src/code_gen/python/des.rs
+++ b/postcard-bindgen-core/src/code_gen/python/des.rs
@@ -6,7 +6,7 @@ use crate::{
         utils::{TokensBranchedIterExt, TokensIterExt},
     },
     registry::BindingType,
-    utils::StrExt,
+    // utils::StrExt,
 };
 
 pub fn gen_deserializer_code() -> Tokens {
@@ -91,7 +91,8 @@ pub fn gen_des_functions(bindings: impl AsRef<[BindingType]>) -> Tokens {
 }
 
 fn gen_des_function_for_type(binding_type: &BindingType) -> Tokens {
-    let obj_name = binding_type.inner_name().to_obj_identifier();
+    // let obj_name = binding_type.inner_name().to_obj_identifier();
+    let obj_name = String::from(binding_type.inner_name());
     let des_body = binding_type.gen_des_body();
     quote! {
         def deserialize_$(&obj_name)(d) -> $obj_name:
@@ -136,7 +137,8 @@ pub fn gen_deserialize_func(tys: impl AsRef<[BindingType]>) -> Tokens {
 
 fn gen_des_case(define: &BindingType) -> (Tokens, Tokens) {
     let name = define.inner_name();
-    let type_name = name.to_obj_identifier();
+    // let type_name = name.to_obj_identifier();
+    let type_name = String::from(name);
     (
         quote!(obj_type is $(&type_name)),
         quote!(return cast(T, deserialize_$type_name(d))),

--- a/postcard-bindgen-core/src/code_gen/python/des.rs
+++ b/postcard-bindgen-core/src/code_gen/python/des.rs
@@ -6,7 +6,6 @@ use crate::{
         utils::{TokensBranchedIterExt, TokensIterExt},
     },
     registry::BindingType,
-    // utils::StrExt,
 };
 
 pub fn gen_deserializer_code() -> Tokens {
@@ -91,11 +90,10 @@ pub fn gen_des_functions(bindings: impl AsRef<[BindingType]>) -> Tokens {
 }
 
 fn gen_des_function_for_type(binding_type: &BindingType) -> Tokens {
-    // let obj_name = binding_type.inner_name().to_obj_identifier();
-    let obj_name = String::from(binding_type.inner_name());
+    let type_name = binding_type.inner_name().to_owned();
     let des_body = binding_type.gen_des_body();
     quote! {
-        def deserialize_$(&obj_name)(d) -> $obj_name:
+        def deserialize_$(&type_name)(d) -> $type_name:
             $des_body
     }
 }
@@ -136,9 +134,7 @@ pub fn gen_deserialize_func(tys: impl AsRef<[BindingType]>) -> Tokens {
 }
 
 fn gen_des_case(define: &BindingType) -> (Tokens, Tokens) {
-    let name = define.inner_name();
-    // let type_name = name.to_obj_identifier();
-    let type_name = String::from(name);
+    let type_name = define.inner_name().to_owned();
     (
         quote!(obj_type is $(&type_name)),
         quote!(return cast(T, deserialize_$type_name(d))),

--- a/postcard-bindgen-core/src/code_gen/python/generateable/container/structs.rs
+++ b/postcard-bindgen-core/src/code_gen/python/generateable/container/structs.rs
@@ -19,6 +19,7 @@ impl BindingTypeGenerateable for StructType {
         self.fields
             .iter()
             .map(|field| {
+                // println!("-> {:?}", field.v_type);
                 field.v_type.gen_ser_accessor(
                     VariablePath::default().modify_push(VariableAccess::Field(field.name.into())),
                 )

--- a/postcard-bindgen-core/src/code_gen/python/generateable/types/object.rs
+++ b/postcard-bindgen-core/src/code_gen/python/generateable/types/object.rs
@@ -3,24 +3,27 @@ use genco::quote;
 use crate::{
     code_gen::python::{FieldAccessor, ImportRegistry, Tokens, VariablePath},
     type_info::ObjectMeta,
-    utils::StrExt,
+    // utils::StrExt,
 };
 
 use super::PythonTypeGenerateable;
 
 impl PythonTypeGenerateable for ObjectMeta {
     fn gen_ser_accessor(&self, variable_path: VariablePath) -> Tokens {
-        let obj_ident = self.name.to_obj_identifier();
+        // let obj_ident = self.name.to_obj_identifier();
+        let obj_ident = String::from(self.name);
         quote!(serialize_$obj_ident(s, $variable_path))
     }
 
     fn gen_des_accessor(&self, field_accessor: FieldAccessor) -> Tokens {
-        let obj_ident = self.name.to_obj_identifier();
+        // let obj_ident = self.name.to_obj_identifier();
+        let obj_ident = String::from(self.name);
         quote!($(field_accessor)deserialize_$obj_ident(d))
     }
 
     fn gen_ty_check(&self, variable_path: VariablePath) -> Tokens {
-        let obj_ident = self.name.to_obj_identifier();
+        // let obj_ident = self.name.to_obj_identifier();
+        let obj_ident = String::from(self.name);
         quote!(assert_$obj_ident($variable_path))
     }
 

--- a/postcard-bindgen-core/src/code_gen/python/ser.rs
+++ b/postcard-bindgen-core/src/code_gen/python/ser.rs
@@ -6,7 +6,7 @@ use crate::{
         utils::{TokensBranchedIterExt, TokensIterExt},
     },
     registry::BindingType,
-    utils::StrExt,
+    // utils::StrExt,
 };
 
 pub fn gen_serializer_code() -> Tokens {
@@ -73,8 +73,10 @@ pub fn gen_ser_functions(bindings: impl AsRef<[BindingType]>) -> Tokens {
 }
 
 fn gen_ser_function_for_type(binding_type: &BindingType) -> Tokens {
-    let obj_name = binding_type.inner_name().to_obj_identifier();
+    // let obj_name = binding_type.inner_name().to_obj_identifier();
+    let obj_name = String::from(binding_type.inner_name());
     let ser_body = binding_type.gen_ser_body();
+    // println!("-> {:?}", ser_body);
     quote! {
         def serialize_$(&obj_name)(s, $PYTHON_OBJECT_VARIABLE):
             $ser_body
@@ -125,7 +127,8 @@ pub fn gen_serialize_func(tys: impl AsRef<[BindingType]>, runtime_type_checks: b
 
 fn gen_ser_case(define: &BindingType, runtime_type_checks: bool) -> (Tokens, Tokens) {
     let name = define.inner_name();
-    let type_name = name.to_obj_identifier();
+    // let type_name = name.to_obj_identifier();
+    let type_name = String::from(name);
 
     let case_body = {
         let mut tokens = Tokens::new();

--- a/postcard-bindgen-core/src/code_gen/python/ser.rs
+++ b/postcard-bindgen-core/src/code_gen/python/ser.rs
@@ -6,7 +6,6 @@ use crate::{
         utils::{TokensBranchedIterExt, TokensIterExt},
     },
     registry::BindingType,
-    // utils::StrExt,
 };
 
 pub fn gen_serializer_code() -> Tokens {
@@ -73,12 +72,10 @@ pub fn gen_ser_functions(bindings: impl AsRef<[BindingType]>) -> Tokens {
 }
 
 fn gen_ser_function_for_type(binding_type: &BindingType) -> Tokens {
-    // let obj_name = binding_type.inner_name().to_obj_identifier();
-    let obj_name = String::from(binding_type.inner_name());
+    let type_name = binding_type.inner_name().to_owned();
     let ser_body = binding_type.gen_ser_body();
-    // println!("-> {:?}", ser_body);
     quote! {
-        def serialize_$(&obj_name)(s, $PYTHON_OBJECT_VARIABLE):
+        def serialize_$(&type_name)(s, $PYTHON_OBJECT_VARIABLE):
             $ser_body
     }
 }
@@ -126,10 +123,7 @@ pub fn gen_serialize_func(tys: impl AsRef<[BindingType]>, runtime_type_checks: b
 }
 
 fn gen_ser_case(define: &BindingType, runtime_type_checks: bool) -> (Tokens, Tokens) {
-    let name = define.inner_name();
-    // let type_name = name.to_obj_identifier();
-    let type_name = String::from(name);
-
+    let type_name = define.inner_name().to_owned();
     let case_body = {
         let mut tokens = Tokens::new();
 

--- a/postcard-bindgen-core/src/code_gen/python/type_checks.rs
+++ b/postcard-bindgen-core/src/code_gen/python/type_checks.rs
@@ -6,7 +6,7 @@ use crate::{
         utils::TokensIterExt,
     },
     registry::BindingType,
-    utils::StrExt,
+    // utils::StrExt,
 };
 
 use super::Tokens;
@@ -20,7 +20,8 @@ pub fn gen_type_checkings(bindings: impl AsRef<[BindingType]>) -> Tokens {
 }
 
 fn gen_type_check(binding_type: &BindingType) -> Tokens {
-    let type_name = binding_type.inner_name().to_obj_identifier();
+    // let type_name = binding_type.inner_name().to_obj_identifier();
+    let type_name = String::from(binding_type.inner_name());
     let body = binding_type.gen_ty_check_body();
     quote! {
         def assert_$type_name($PYTHON_OBJECT_VARIABLE):


### PR DESCRIPTION
Python type names can be `FooBar` in some places and `FOOBAR` in others. Further, the serializer and deserializer functions will be `serialize_FOOBAR` and `deserialize_FOOBAR`. This naming misalignment causes errors, and this PR attempts to fix it.

I adjusted the example to generate both Javascript and Python bindings. 

Also, the fix I implemented is quick and possibly not ideal in the context of the overall codebase. I have made the PR a draft PR as a result. Please let me know if there is a better way to achieve what I am trying to do. 